### PR TITLE
Fix project sorting on listing pages to use creation date

### DIFF
--- a/src/pages/projects.en.js
+++ b/src/pages/projects.en.js
@@ -57,7 +57,7 @@ const PageTemplate = styled.div`
 const ProjectsIndex = () => {
 	const data = useStaticQuery(graphql`
 		{
-			allContentfulProject(sort: { contentfulid: ASC }) {
+			allContentfulProject(sort: { createdAt: DESC }) {
 				nodes {
 					contentfulid
 					language

--- a/src/pages/projects.pl.js
+++ b/src/pages/projects.pl.js
@@ -57,7 +57,7 @@ const PageTemplate = styled.div`
 const ProjectsIndex = () => {
 	const data = useStaticQuery(graphql`
 		{
-			allContentfulProject(sort: { contentfulid: ASC }) {
+			allContentfulProject(sort: { createdAt: DESC }) {
 				nodes {
 					contentfulid
 					language


### PR DESCRIPTION
The projects listing pages (projects.en.js and projects.pl.js) were
sorting by contentfulid ASC instead of createdAt DESC, causing projects
to appear in the wrong order. The homepage Projects component already
used the correct createdAt sorting. This aligns both listing pages
with that approach so newest projects (like Mc booking) appear first.

https://claude.ai/code/session_01QwiQ4BmnM1r1ks5rEr3BhJ