### PR TITLE
Fix project sorting on main page to match projects page order

### DIFF
--- a/src/pages/index.en.js
+++ b/src/pages/index.en.js
@@ -111,7 +111,7 @@ export const pageQuery = graphql`
 				tags
 			}
 		}
-		allContentfulProject(sort: { contentfulid: ASC }) {
+		allContentfulProject(sort: { createdAt: DESC }) {
 			nodes {
 				contentfulid
 				language

--- a/src/pages/index.pl.js
+++ b/src/pages/index.pl.js
@@ -110,7 +110,7 @@ export const pageQuery = graphql`
 				tags
 			}
 		}
-		allContentfulProject(sort: { contentfulid: ASC }) {
+		allContentfulProject(sort: { createdAt: DESC }) {
 			nodes {
 				contentfulid
 				language


### PR DESCRIPTION
The main page (index.en.js, index.pl.js) was sorting projects by contentfulid ASC, while the projects listing pages sort by createdAt DESC. Changed main page queries to use createdAt DESC for consistent ordering.

https://claude.ai/code/session_01QwiQ4BmnM1r1ks5rEr3BhJ