### PR TITLE
Refactor atoms/Button: theme tokens, transient props, real disabled state

### DIFF
--- a/src/components/atoms/Button/Button.js
+++ b/src/components/atoms/Button/Button.js
@@ -1,6 +1,45 @@
-import PropTypes from "prop-types";
-import React from "react";
-import styled, { css, keyframes } from "styled-components";
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled, { css, keyframes } from 'styled-components';
+
+const isExternalLink = url =>
+	typeof url === 'string' && /^(https?:)?\/\//.test(url);
+
+const neonGlow = color => css`
+	box-shadow:
+		0 0 5px ${color},
+		0 0 25px ${color},
+		0 0 50px ${color},
+		0 0 200px ${color};
+	-webkit-box-reflect: below 1px linear-gradient(transparent, #0005);
+`;
+
+const variantStyles = {
+	blue: css`
+		background: ${({ theme }) => theme.neonBlue};
+		color: ${({ theme }) => theme.dark};
+		&:hover {
+			background: ${({ theme }) => theme.dark};
+			color: ${({ theme }) => theme.neonBlue};
+		}
+	`,
+	green: css`
+		background: ${({ theme }) => theme.green};
+		color: ${({ theme }) => theme.dark};
+		&:hover {
+			background: ${({ theme }) => theme.green};
+			color: ${({ theme }) => theme.dark};
+		}
+	`,
+	red: css`
+		background: ${({ theme }) => theme.red};
+		color: ${({ theme }) => theme.dark};
+		&:hover {
+			background: ${({ theme }) => theme.red};
+			color: ${({ theme }) => theme.dark};
+		}
+	`,
+};
 
 const StyledButton = styled.button`
 	position: relative;
@@ -8,7 +47,7 @@ const StyledButton = styled.button`
 	font-size: ${({ theme }) => theme.fontSize.xs};
 	font-weight: ${({ theme }) => theme.regular};
 	text-align: center;
-	background: #03e9f4;
+	background: ${({ theme }) => theme.neonBlue};
 	color: ${({ theme }) => theme.dark};
 	display: inline-block;
 	font-family: ${({ theme }) => theme.fonts.subFont};
@@ -18,231 +57,189 @@ const StyledButton = styled.button`
 	transition: 0.5s;
 	letter-spacing: 4px;
 	overflow: hidden;
-	margin-right: 20px;
+	border: none;
+
 	&:hover {
 		background: ${({ theme }) => theme.dark};
 		color: ${({ theme }) => theme.neonBlue};
-		${({ animation }) =>
-			animation &&
-			css`
-				&:hover {
-					background: #03e9f4;
-					color: ${({ theme }) => theme.dark};
-					box-shadow: 0 0 5px #03e9f4, 0 0 25px #03e9f4, 0 0 50px #03e9f4,
-						0 0 200px #03e9f4;
-					-webkit-box-reflect: below 1px linear-gradient(transparent, #0005);
-				}
-			`}
 	}
-	${({ animation }) =>
-		animation &&
+
+	${({ $animated, theme }) =>
+		$animated &&
 		css`
 			background: transparent;
-			color: #16ffff;
-		`};
-	${({ color }) =>
-		color === "blue" &&
-		css`
-			background: #03e9f4;
-			color: ${({ theme }) => theme.dark};
-		`};
-	${({ color }) =>
-		color === "green" &&
-		css`
-			border-color: ${({ theme }) => theme.dark};
-			background: ${({ theme }) => theme.green};
+			color: ${theme.neonBlue};
 			&:hover {
-				background: ${({ theme }) => theme.green};
-				color: ${({ theme }) => theme.dark};
+				background: ${theme.neonBlue};
+				color: ${theme.dark};
+				${neonGlow(theme.neonBlue)};
 			}
 		`};
-	${({ color }) =>
-		color === "red" &&
-		css`
-			background: ${({ theme }) => theme.red};
-			&:hover {
-				background: ${({ theme }) => theme.red};
-				color: ${({ theme }) => theme.dark};
-			}
-		`};
+
+	${({ $color }) => $color && variantStyles[$color]};
+
+	&:disabled,
+	&[aria-disabled='true'] {
+		cursor: not-allowed;
+		opacity: 0.6;
+	}
+
 	${({ theme }) => theme.mq.s} {
 		font-size: ${({ theme }) => theme.fontSize.lg};
 		padding: 20px;
-		margin-right: 50px;
 	}
 `;
 
-const animate1 = keyframes`  
-    0%{
-        left: -100%;
-    }
-    50%,100%{
-        left: 100%;
-    }
+const animate1 = keyframes`
+	0% { left: -100%; }
+	50%, 100% { left: 100%; }
 `;
 const animate2 = keyframes`
-    0%{
-        top: -100%;
-    }
-    50%,100%{
-        top: 100%;
-    }
+	0% { top: -100%; }
+	50%, 100% { top: 100%; }
 `;
 const animate3 = keyframes`
-    0%{
-        right: -100%;
-    }
-    50%,100%{
-        right: 100%;
-    }
+	0% { right: -100%; }
+	50%, 100% { right: 100%; }
 `;
 const animate4 = keyframes`
-    0%{
-        bottom: -100%;
-    }
-    50%,100%{
-        bottom: 100%;
-    }
+	0% { bottom: -100%; }
+	50%, 100% { bottom: 100%; }
 `;
 
 const StyledSpan = styled.span`
 	position: absolute;
 	display: block;
+	background: ${({ $color, theme }) =>
+		$color === 'green' || $color === 'red' ? theme.dark : theme.neonBlue};
+
 	&:nth-child(1) {
 		top: 0;
 		left: 0;
 		width: 100%;
 		height: 2px;
-		background: #03e9f4;
-		${({ animation }) =>
-			animation &&
+		${({ $animated, theme }) =>
+			$animated &&
 			css`
-				background: linear-gradient(90deg, transparent, #03e9f4);
+				background: linear-gradient(90deg, transparent, ${theme.neonBlue});
 				animation: ${animate1} 1s linear infinite;
-			`};
-		${({ color }) =>
-			color === "green" &&
-			css`
-				background: ${({ theme }) => theme.dark};
-			`};
-		${({ color }) =>
-			color === "red" &&
-			css`
-				background: ${({ theme }) => theme.dark};
-			`};
+			`}
 	}
 	&:nth-child(2) {
 		top: 0;
 		right: 0;
 		width: 2px;
 		height: 100%;
-		background: #03e9f4;
-		${({ animation }) =>
-			animation &&
+		${({ $animated, theme }) =>
+			$animated &&
 			css`
 				top: -100%;
-				background: linear-gradient(180deg, transparent, #03e9f4);
+				background: linear-gradient(180deg, transparent, ${theme.neonBlue});
 				animation: ${animate2} 1s linear infinite;
 				animation-delay: 0.25s;
 			`}
-		${({ color }) =>
-			color === "green" &&
-			css`
-				background: ${({ theme }) => theme.dark};
-			`};
-		${({ color }) =>
-			color === "red" &&
-			css`
-				background: ${({ theme }) => theme.dark};
-			`};
 	}
 	&:nth-child(3) {
 		bottom: 0;
 		right: 0;
 		width: 100%;
 		height: 2px;
-		background: #03e9f4;
-		${({ animation }) =>
-			animation &&
+		${({ $animated, theme }) =>
+			$animated &&
 			css`
-				background: linear-gradient(270deg, transparent, #03e9f4);
+				background: linear-gradient(270deg, transparent, ${theme.neonBlue});
 				animation: ${animate3} 1s linear infinite;
 				animation-delay: 0.5s;
 			`}
-		${({ color }) =>
-			color === "green" &&
-			css`
-				background: ${({ theme }) => theme.dark};
-			`};
-		${({ color }) =>
-			color === "red" &&
-			css`
-				background: ${({ theme }) => theme.dark};
-			`};
 	}
 	&:nth-child(4) {
 		bottom: 0;
 		left: 0;
 		width: 2px;
 		height: 100%;
-		background: #03e9f4;
-		${({ animation }) =>
-			animation &&
+		${({ $animated, theme }) =>
+			$animated &&
 			css`
 				bottom: -100%;
-				background: linear-gradient(360deg, transparent, #03e9f4);
+				background: linear-gradient(360deg, transparent, ${theme.neonBlue});
 				animation: ${animate4} 1s linear infinite;
 				animation-delay: 0.75s;
 			`}
-		${({ color }) =>
-			color === "green" &&
-			css`
-				background: ${({ theme }) => theme.dark};
-			`};
-		${({ color }) =>
-			color === "red" &&
-			css`
-				background: ${({ theme }) => theme.dark};
-			`};
+	}
+
+	[disabled] &,
+	[aria-disabled='true'] & {
+		animation: none;
 	}
 `;
 
 const Button = ({
 	label,
-	link = "",
+	link = '',
 	animated = false,
-	renderAs = "button",
+	renderAs = 'button',
 	color,
 	className,
-	clickHandler = null,
-	type = undefined,
+	onClick,
+	type,
+	disabled = false,
+	title,
+	target,
+	rel,
 }) => {
+	const renderAsAnchor = renderAs === 'a' && Boolean(link);
+	const tag = renderAsAnchor ? 'a' : 'button';
+	const external = isExternalLink(link);
+
+	const anchorProps = renderAsAnchor
+		? {
+				href: link,
+				target: target ?? (external ? '_blank' : undefined),
+				rel: rel ?? (external ? 'noopener noreferrer' : undefined),
+			}
+		: {};
+
+	const buttonProps =
+		tag === 'button'
+			? {
+					type: type ?? 'button',
+					disabled,
+				}
+			: {};
+
 	return (
 		<StyledButton
+			as={tag}
 			className={className}
-			color={color}
-			href={link || undefined}
-			role={renderAs === "a" ? "link" : "button"}
-			target={renderAs === "a" ? "_blank" : undefined}
-			rel={renderAs === "a" ? "noopener noreferrer" : undefined}
-			as={renderAs}
-			animation={animated}
-			onClick={clickHandler}
-			type={type}>
-			<StyledSpan color={color} animation={animated}></StyledSpan>
-			<StyledSpan color={color} animation={animated}></StyledSpan>
-			<StyledSpan color={color} animation={animated}></StyledSpan>
-			<StyledSpan color={color} animation={animated}></StyledSpan>
+			$color={color}
+			$animated={animated}
+			title={title}
+			onClick={disabled ? undefined : onClick}
+			aria-disabled={disabled || undefined}
+			{...anchorProps}
+			{...buttonProps}>
+			<StyledSpan aria-hidden="true" $color={color} $animated={animated} />
+			<StyledSpan aria-hidden="true" $color={color} $animated={animated} />
+			<StyledSpan aria-hidden="true" $color={color} $animated={animated} />
+			<StyledSpan aria-hidden="true" $color={color} $animated={animated} />
 			{label}
 		</StyledButton>
 	);
 };
 
 Button.propTypes = {
-	animated: PropTypes.bool,
 	label: PropTypes.string.isRequired,
 	link: PropTypes.string,
-	renderAs: PropTypes.string,
+	animated: PropTypes.bool,
+	renderAs: PropTypes.oneOf(['button', 'a']),
+	color: PropTypes.oneOf(['blue', 'green', 'red']),
+	className: PropTypes.string,
+	onClick: PropTypes.func,
+	type: PropTypes.oneOf(['button', 'submit', 'reset']),
+	disabled: PropTypes.bool,
+	title: PropTypes.string,
+	target: PropTypes.string,
+	rel: PropTypes.string,
 };
 
 export default Button;

--- a/src/components/atoms/Button/__tests__/Button.test.js
+++ b/src/components/atoms/Button/__tests__/Button.test.js
@@ -1,52 +1,114 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import React from "react";
-import { ThemeProvider } from "styled-components";
-import { theme } from "../../../../theme/mainTheme";
-import Button from "../Button";
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '../../../../theme/mainTheme';
+import Button from '../Button';
 
 const renderWithTheme = ui =>
 	render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
 
-describe("Button", () => {
-	it("renders the label text", () => {
+describe('Button', () => {
+	it('renders the label text', () => {
 		renderWithTheme(<Button label="Click me" />);
-		expect(screen.getByText("Click me")).toBeInTheDocument();
+		expect(screen.getByText('Click me')).toBeInTheDocument();
 	});
 
-	it("renders as a <button> element by default", () => {
+	it('renders as a <button> element by default', () => {
 		renderWithTheme(<Button label="Click me" />);
-		expect(screen.getByRole("button")).toBeInTheDocument();
+		const btn = screen.getByRole('button');
+		expect(btn.tagName).toBe('BUTTON');
+		expect(btn).toHaveAttribute('type', 'button');
 	});
 
-	it("renders as an <a> element when renderAs='a'", () => {
+	it("renders as an <a> element when renderAs='a' with a link", () => {
 		renderWithTheme(
-			<Button label="Visit" renderAs="a" link="https://example.com" />
+			<Button label="Visit" renderAs="a" link="https://example.com" />,
 		);
-		const el = screen.getByRole("link");
-		expect(el).toBeInTheDocument();
-		expect(el).toHaveAttribute("href", "https://example.com");
-		expect(el).toHaveAttribute("target", "_blank");
+		const el = screen.getByRole('link');
+		expect(el.tagName).toBe('A');
+		expect(el).toHaveAttribute('href', 'https://example.com');
+		expect(el).toHaveAttribute('target', '_blank');
+		expect(el).toHaveAttribute('rel', 'noopener noreferrer');
 	});
 
-	it("sets rel='noopener noreferrer' on link buttons", () => {
+	it("falls back to <button> when renderAs='a' but no link is provided", () => {
+		renderWithTheme(<Button label="No link" renderAs="a" />);
+		expect(screen.getByRole('button').tagName).toBe('BUTTON');
+		expect(screen.queryByRole('link')).not.toBeInTheDocument();
+	});
+
+	it('does not set target/rel for internal (relative) links', () => {
+		renderWithTheme(<Button label="Internal" renderAs="a" link="/about" />);
+		const el = screen.getByRole('link');
+		expect(el).toHaveAttribute('href', '/about');
+		expect(el).not.toHaveAttribute('target');
+		expect(el).not.toHaveAttribute('rel');
+	});
+
+	it('allows overriding target and rel', () => {
 		renderWithTheme(
-			<Button label="Visit" renderAs="a" link="https://example.com" />
+			<Button
+				label="Same tab"
+				renderAs="a"
+				link="https://example.com"
+				target="_self"
+				rel="nofollow"
+			/>,
 		);
-		expect(screen.getByRole("link")).toHaveAttribute(
-			"rel",
-			"noopener noreferrer"
-		);
+		const el = screen.getByRole('link');
+		expect(el).toHaveAttribute('target', '_self');
+		expect(el).toHaveAttribute('rel', 'nofollow');
 	});
 
-	it("calls clickHandler when clicked", () => {
+	it('calls onClick when clicked', () => {
 		const handler = jest.fn();
-		renderWithTheme(<Button label="Click me" clickHandler={handler} />);
-		fireEvent.click(screen.getByRole("button"));
+		renderWithTheme(<Button label="Click me" onClick={handler} />);
+		fireEvent.click(screen.getByRole('button'));
 		expect(handler).toHaveBeenCalledTimes(1);
 	});
 
-	it("renders 4 decorative span children", () => {
+	it('does not call onClick when disabled', () => {
+		const handler = jest.fn();
+		renderWithTheme(<Button label="Click me" onClick={handler} disabled />);
+		fireEvent.click(screen.getByRole('button'));
+		expect(handler).not.toHaveBeenCalled();
+	});
+
+	it('sets the disabled attribute when disabled', () => {
+		renderWithTheme(<Button label="Click me" disabled />);
+		expect(screen.getByRole('button')).toBeDisabled();
+	});
+
+	it('forwards the title attribute', () => {
+		renderWithTheme(<Button label="Visit" title="Open project site" />);
+		expect(screen.getByRole('button')).toHaveAttribute(
+			'title',
+			'Open project site',
+		);
+	});
+
+	it('does not leak transient props to the DOM', () => {
+		renderWithTheme(<Button label="Click me" color="green" animated />);
+		const btn = screen.getByRole('button');
+		expect(btn).not.toHaveAttribute('color');
+		expect(btn).not.toHaveAttribute('animation');
+		expect(btn).not.toHaveAttribute('animated');
+		expect(btn).not.toHaveAttribute('$color');
+		expect(btn).not.toHaveAttribute('$animated');
+	});
+
+	it('renders 4 decorative spans marked aria-hidden', () => {
 		const { container } = renderWithTheme(<Button label="Click me" />);
-		expect(container.querySelectorAll("span")).toHaveLength(4);
+		const spans = container.querySelectorAll('span');
+		expect(spans).toHaveLength(4);
+		spans.forEach(span => {
+			expect(span).toHaveAttribute('aria-hidden', 'true');
+		});
+	});
+
+	it('uses the submit type when requested', () => {
+		renderWithTheme(<Button label="Send" type="submit" />);
+		expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
 	});
 });

--- a/src/components/molecules/Forms/CommentForm.js
+++ b/src/components/molecules/Forms/CommentForm.js
@@ -4,15 +4,15 @@ import {
 	doc,
 	increment,
 	updateDoc,
-} from "firebase/firestore";
-import { Field, Form, Formik } from "formik";
-import React, { useState } from "react";
-import styled, { css } from "styled-components";
-import * as Yup from "yup";
+} from 'firebase/firestore';
+import { Field, Form, Formik } from 'formik';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import * as Yup from 'yup';
 
-import { db } from "../../../services/firebase";
-import Button from "../../atoms/Button/Button";
-import FormInput from "./FormInput";
+import { db } from '../../../services/firebase';
+import Button from '../../atoms/Button/Button';
+import FormInput from './FormInput';
 
 const StyledFormInput = styled(FormInput)`
 	padding: 0.5rem 1rem;
@@ -25,61 +25,52 @@ const Honeypot = styled(Field)`
 const SubmitButton = styled(Button)`
 	font-size: ${({ theme }) => theme.fontSize.s};
 	padding: 15px 10px;
-	cursor: pointer;
-	margin-top: 15px !important;
+	margin-top: 15px;
 	${({ theme }) => theme.mq.s} {
 		margin-top: 30px;
 	}
-	${({ disabled }) =>
-		disabled &&
-		css`
-			content: "";
-			background: #03e9f4;
-			color: ${({ theme }) => theme.dark};
-			cursor: default;
-		`}
 `;
 
 const CommentSchemaEn = Yup.object().shape({
-	author: Yup.string().required("Your name is required!"),
-	content: Yup.string().required("Provide comment message!"),
+	author: Yup.string().required('Your name is required!'),
+	content: Yup.string().required('Provide comment message!'),
 });
 const CommentSchemaPl = Yup.object().shape({
-	author: Yup.string().required("Podaj swoje imię"),
-	content: Yup.string().required("Wpisz treść komentarza"),
+	author: Yup.string().required('Podaj swoje imię'),
+	content: Yup.string().required('Wpisz treść komentarza'),
 });
 
 const initialValues = {
-	author: "",
-	content: "",
+	author: '',
+	content: '',
 	honeypot: false,
 };
 
 const CommentForm = ({ lang, postId, parentId = null }) => {
 	let initialSubmitBtnContent, successSubmitBtnContent, errorSubmitBtnContent;
 
-	if (lang === "en") {
+	if (lang === 'en') {
 		initialSubmitBtnContent = {
-			content: "Submit",
-			color: "blue",
+			content: 'Submit',
+			color: 'blue',
 		};
 		successSubmitBtnContent = {
-			content: "Success!",
-			color: "green",
+			content: 'Success!',
+			color: 'green',
 		};
-		errorSubmitBtnContent = { content: "Something went wrong!", color: "red" };
-	} else if (lang === "pl") {
+		errorSubmitBtnContent = { content: 'Something went wrong!', color: 'red' };
+	} else if (lang === 'pl') {
 		initialSubmitBtnContent = {
-			content: "Wyślij",
-			color: "blue",
+			content: 'Wyślij',
+			color: 'blue',
 		};
 		successSubmitBtnContent = {
-			content: "Wysłano!",
-			color: "green",
+			content: 'Wysłano!',
+			color: 'green',
 		};
 		errorSubmitBtnContent = {
-			content: "Coś poszło nie tak :(",
-			color: "red",
+			content: 'Coś poszło nie tak :(',
+			color: 'red',
 		};
 	}
 
@@ -92,7 +83,7 @@ const CommentForm = ({ lang, postId, parentId = null }) => {
 	const sendForm = (values, { setSubmitting, resetForm }) => {
 		const sendComment = async () => {
 			try {
-				await addDoc(collection(db, "comments"), {
+				await addDoc(collection(db, 'comments'), {
 					author: values.author,
 					content: values.content,
 					postId,
@@ -107,13 +98,13 @@ const CommentForm = ({ lang, postId, parentId = null }) => {
 				setSubmitting(false);
 				setSubmitBtn(errorSubmitBtnContent);
 				setTimeout(clearButton, 1500);
-				console.warn("Error adding document: ", e);
+				console.warn('Error adding document: ', e);
 			}
 		};
 
 		const sendBotInfo = async () => {
 			try {
-				const counterRef = doc(db, "bot-info", "counter");
+				const counterRef = doc(db, 'bot-info', 'counter');
 
 				await updateDoc(counterRef, {
 					value: increment(1),
@@ -126,20 +117,19 @@ const CommentForm = ({ lang, postId, parentId = null }) => {
 				setSubmitting(false);
 				setSubmitBtn(errorSubmitBtnContent);
 				setTimeout(clearButton, 1500);
-				console.warn("Error adding document: ", e);
+				console.warn('Error adding document: ', e);
 			}
 		};
 
 		values.honeypot ? sendBotInfo() : sendComment();
 	};
 
-	if (lang === "en") {
+	if (lang === 'en') {
 		return (
 			<Formik
 				initialValues={initialValues}
 				validationSchema={CommentSchemaEn}
-				onSubmit={sendForm}
-			>
+				onSubmit={sendForm}>
 				{({
 					values,
 					errors,
@@ -173,23 +163,19 @@ const CommentForm = ({ lang, postId, parentId = null }) => {
 						<SubmitButton
 							color={submitBtn.color}
 							label={submitBtn.content}
-							disabled={isSubmitting || submitBtn.color !== "blue"}
-							isSubmitting={isSubmitting}
+							disabled={isSubmitting || submitBtn.color !== 'blue'}
 							type="submit"
-						>
-							{!isSubmitting && submitBtn.content}
-						</SubmitButton>
+						/>
 					</Form>
 				)}
 			</Formik>
 		);
-	} else if (lang === "pl") {
+	} else if (lang === 'pl') {
 		return (
 			<Formik
 				initialValues={initialValues}
 				validationSchema={CommentSchemaPl}
-				onSubmit={sendForm}
-			>
+				onSubmit={sendForm}>
 				{({
 					values,
 					errors,
@@ -223,12 +209,9 @@ const CommentForm = ({ lang, postId, parentId = null }) => {
 						<SubmitButton
 							color={submitBtn.color}
 							label={submitBtn.content}
-							disabled={isSubmitting || submitBtn.color !== "blue"}
-							isSubmitting={isSubmitting}
+							disabled={isSubmitting || submitBtn.color !== 'blue'}
 							type="submit"
-						>
-							{!isSubmitting && submitBtn.content}
-						</SubmitButton>
+						/>
 					</Form>
 				)}
 			</Formik>

--- a/src/components/molecules/Forms/ContactForm.js
+++ b/src/components/molecules/Forms/ContactForm.js
@@ -1,85 +1,74 @@
-import { Field, Form, Formik } from "formik";
-import React, { useState } from "react";
-import styled, { css } from "styled-components";
-import * as Yup from "yup";
+import { Field, Form, Formik } from 'formik';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import * as Yup from 'yup';
 
-import Button from "../../atoms/Button/Button";
-import FormInput from "./FormInput";
+import Button from '../../atoms/Button/Button';
+import FormInput from './FormInput';
 
 const SubmitButton = styled(Button)`
-	&& {
-		cursor: pointer;
-		width: 100%;
-		margin-top: 15px !important;
-	}
+	width: 100%;
+	margin-top: 15px;
 	${({ theme }) => theme.mq.s} {
 		margin-top: 30px;
 	}
-	${({ disabled }) =>
-		disabled &&
-		css`
-			content: "";
-			background: #03e9f4;
-			color: ${({ theme }) => theme.dark};
-			cursor: default;
-		`}
 `;
 
 export const ContactSchemaEn = Yup.object().shape({
-	name: Yup.string().required("Your name is required!"),
+	name: Yup.string().required('Your name is required!'),
 	email: Yup.string()
-		.email("Email address is invalid!")
-		.required("Email address is required!"),
+		.email('Email address is invalid!')
+		.required('Email address is required!'),
 	message: Yup.string()
-		.min(10, "Message is too short!")
-		.required("Message is required!"),
+		.min(10, 'Message is too short!')
+		.required('Message is required!'),
 });
 export const ContactSchemaPl = Yup.object().shape({
-	name: Yup.string().required("Podaj swoje imię"),
+	name: Yup.string().required('Podaj swoje imię'),
 	email: Yup.string()
-		.email("Adres email jest niepoprawny")
-		.required("Wpisz swój adres email"),
+		.email('Adres email jest niepoprawny')
+		.required('Wpisz swój adres email'),
 	message: Yup.string()
-		.min(10, "Wiadomość jest za krótka")
-		.required("Podaj treść wiadomości"),
+		.min(10, 'Wiadomość jest za krótka')
+		.required('Podaj treść wiadomości'),
 });
 
 const initialValues = {
-	name: "",
-	email: "",
-	message: "",
+	name: '',
+	email: '',
+	message: '',
 };
 
 const encode = data => {
 	return Object.keys(data)
-		.map(key => encodeURIComponent(key) + "=" + encodeURIComponent(data[key]))
-		.join("&");
+		.map(key => encodeURIComponent(key) + '=' + encodeURIComponent(data[key]))
+		.join('&');
 };
 
 const ContactForm = ({ lang }) => {
 	let initialSubmitBtnContent, successSubmitBtnContent, errorSubmitBtnContent;
-	if (lang === "en") {
+	if (lang === 'en') {
 		initialSubmitBtnContent = {
-			content: "Send message",
-			color: "blue",
+			content: 'Send message',
+			color: 'blue',
 		};
 		successSubmitBtnContent = {
-			content: "Success!",
-			color: "green",
+			content: 'Success!',
+			color: 'green',
 		};
-		errorSubmitBtnContent = { content: "Something went wrong!", color: "red" };
-	} else if (lang === "pl") {
+		errorSubmitBtnContent = { content: 'Something went wrong!', color: 'red' };
+	} else if (lang === 'pl') {
 		initialSubmitBtnContent = {
-			content: "Wyślij",
-			color: "blue",
+			content: 'Wyślij',
+			color: 'blue',
 		};
 		successSubmitBtnContent = {
-			content: "Wysłano!",
-			color: "green",
+			content: 'Wysłano!',
+			color: 'green',
 		};
 		errorSubmitBtnContent = {
-			content: "Coś poszło nie tak :(",
-			color: "red",
+			content: 'Coś poszło nie tak :(',
+			color: 'red',
 		};
 	}
 	const [submitBtn, setSubmitBtn] = useState(initialSubmitBtnContent);
@@ -91,13 +80,13 @@ const ContactForm = ({ lang }) => {
 	const sendForm = (values, { setSubmitting, resetForm }) => {
 		const sendMessage = async () => {
 			try {
-				await fetch("/", {
-					method: "POST",
+				await fetch('/', {
+					method: 'POST',
 					headers: {
-						"Content-Type": "application/x-www-form-urlencoded",
+						'Content-Type': 'application/x-www-form-urlencoded',
 					},
 					body: encode({
-						"form-name": "contact-form",
+						'form-name': 'contact-form',
 						...values,
 					}),
 				});
@@ -114,13 +103,12 @@ const ContactForm = ({ lang }) => {
 		sendMessage();
 	};
 
-	if (lang === "en") {
+	if (lang === 'en') {
 		return (
 			<Formik
 				initialValues={initialValues}
 				validationSchema={ContactSchemaEn}
-				onSubmit={sendForm}
-			>
+				onSubmit={sendForm}>
 				{({
 					values,
 					errors,
@@ -135,8 +123,7 @@ const ContactForm = ({ lang }) => {
 						autoComplete="off"
 						name="contact-form"
 						data-netlify="true"
-						data-netlify-honeypot="bot-field"
-					>
+						data-netlify-honeypot="bot-field">
 						<Field type="hidden" name="form-name" />
 						<Field type="hidden" name="bot-field" />
 						<FormInput
@@ -170,23 +157,19 @@ const ContactForm = ({ lang }) => {
 						<SubmitButton
 							color={submitBtn.color}
 							label={submitBtn.content}
-							disabled={isSubmitting || submitBtn.color !== "blue"}
-							isSubmitting={isSubmitting}
+							disabled={isSubmitting || submitBtn.color !== 'blue'}
 							type="submit"
-						>
-							{!isSubmitting && submitBtn.content}
-						</SubmitButton>
+						/>
 					</Form>
 				)}
 			</Formik>
 		);
-	} else if (lang === "pl") {
+	} else if (lang === 'pl') {
 		return (
 			<Formik
 				initialValues={initialValues}
 				validationSchema={ContactSchemaPl}
-				onSubmit={sendForm}
-			>
+				onSubmit={sendForm}>
 				{({
 					values,
 					errors,
@@ -201,8 +184,7 @@ const ContactForm = ({ lang }) => {
 						autoComplete="off"
 						name="contact-form"
 						data-netlify="true"
-						data-netlify-honeypot="bot-field"
-					>
+						data-netlify-honeypot="bot-field">
 						<Field type="hidden" name="form-name" />
 						<Field type="hidden" name="bot-field" />
 						<FormInput
@@ -236,12 +218,9 @@ const ContactForm = ({ lang }) => {
 						<SubmitButton
 							color={submitBtn.color}
 							label={submitBtn.content}
-							disabled={isSubmitting || submitBtn.color !== "blue"}
-							isSubmitting={isSubmitting}
+							disabled={isSubmitting || submitBtn.color !== 'blue'}
 							type="submit"
-						>
-							{!isSubmitting && submitBtn.content}
-						</SubmitButton>
+						/>
 					</Form>
 				)}
 			</Formik>

--- a/src/components/organisms/Comments/Comment.js
+++ b/src/components/organisms/Comments/Comment.js
@@ -1,21 +1,17 @@
-import gsap from "gsap";
-import React, { useEffect, useRef, useState } from "react";
-import styled from "styled-components";
+import gsap from 'gsap';
+import React, { useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
 
-import userIcon from "../../../assets/icons/user.svg";
-import getDate from "../../../utils/getDate";
-import sortBy from "../../../utils/sortBy";
-import Button from "../../atoms/Button/Button";
-import CommentForm from "../../molecules/Forms/CommentForm";
+import userIcon from '../../../assets/icons/user.svg';
+import getDate from '../../../utils/getDate';
+import sortBy from '../../../utils/sortBy';
+import Button from '../../atoms/Button/Button';
+import CommentForm from '../../molecules/Forms/CommentForm';
 
 const ReplyButton = styled(Button)`
-	font-size: ${({ theme }) => theme.fontSize.s} !important;
-	padding: 15px 10px !important;
-	cursor: pointer !important;
-	margin: 30px 0 !important;
-	${({ theme }) => theme.mq.s} {
-		margin-top: 30px;
-	}
+	font-size: ${({ theme }) => theme.fontSize.s};
+	padding: 15px 10px;
+	margin: 30px 0;
 `;
 
 const StyledSingleComment = styled.div`
@@ -25,7 +21,7 @@ const StyledSingleComment = styled.div`
 const CommentContainer = styled.article`
 	border: 1px solid ${({ theme }) => theme.gray};
 	border-radius: 10px;
-	margin: 2rem 0 0 ${props => (props.child ? "20px" : "0")};
+	margin: 2rem 0 0 ${props => (props.child ? '20px' : '0')};
 	padding: 3rem;
 	.flex-container {
 		display: flex;
@@ -51,8 +47,8 @@ const CommentContainer = styled.article`
 
 const SingleComment = ({ comment, lang }) => {
 	const dateObj = comment.timestamp ? new Date(comment.timestamp) : undefined;
-	const time = dateObj ? getDate(dateObj, lang) : "";
-	const timeString = time ? `${time.date} ${time.month} ${time.year}` : "";
+	const time = dateObj ? getDate(dateObj, lang) : '';
+	const timeString = time ? `${time.date} ${time.month} ${time.year}` : '';
 
 	return (
 		<StyledSingleComment>
@@ -79,17 +75,17 @@ const Comment = ({ lang, comment, children, postId }) => {
 			[...commentList.children].map(child => {
 				gsap.from(child, {
 					autoAlpha: 0,
-					y: "-=20",
+					y: '-=20',
 					scrollTrigger: {
 						trigger: child,
-						start: "top bottom-=50px",
+						start: 'top bottom-=50px',
 					},
 				});
 			});
 		}
 	}, []);
 
-	const nestedCommentList = sortBy(children, "timestamp").map(comment => (
+	const nestedCommentList = sortBy(children, 'timestamp').map(comment => (
 		<CommentContainer child className="comment-reply" key={comment.id}>
 			<SingleComment comment={comment} lang={lang} />
 		</CommentContainer>
@@ -104,19 +100,15 @@ const Comment = ({ lang, comment, children, postId }) => {
 				{showReplyBox ? (
 					<div>
 						<ReplyButton
-							renderAs="button"
-							label={lang === "en" ? "Cancel Reply" : "Anuluj"}
-							clickHandler={() => setShowReplyBox(false)}
-							animated={false}
+							label={lang === 'en' ? 'Cancel Reply' : 'Anuluj'}
+							onClick={() => setShowReplyBox(false)}
 						/>
 						<CommentForm lang={lang} parentId={comment.id} postId={postId} />
 					</div>
 				) : (
 					<ReplyButton
-						renderAs="button"
-						label={lang === "en" ? "Reply" : "Odpowiedz"}
-						clickHandler={() => setShowReplyBox(true)}
-						animated={false}
+						label={lang === 'en' ? 'Reply' : 'Odpowiedz'}
+						onClick={() => setShowReplyBox(true)}
 					/>
 				)}
 			</div>


### PR DESCRIPTION
- Replace hard-coded #03e9f4/#16ffff with theme.neonBlue throughout.
- Use styled-components v6 transient props ($color, $animated) so custom
  props no longer leak to the DOM and trigger React/HTML warnings.
- Drop redundant role="button"/role="link" attributes (implicit roles
  already cover both cases).
- Add real disabled state (HTML disabled + aria-disabled, opacity,
  not-allowed cursor, animation halted, onClick suppressed) instead of
  the prior "fake disabled" pattern in form callers.
- Honor the title prop (previously silently dropped by Website tiles).
- Make target/rel overridable; default to _blank only for external links
  so renderAs="a" with an internal href no longer forces a new tab.
- Fall back to <button> when renderAs="a" is set but no link is given
  (avoids invalid <a> with no href).
- Add aria-hidden to the four decorative spans.
- Collapse ~80 lines of duplicated nth-child color overrides into one
  rule; remove dead border-color declarations and the nested
  &:hover { &:hover {} } block.
- Move margin-right out of the atom; layout is the parent's concern.
  This lets ContactForm, CommentForm, and Comments/Comment drop their
  !important overrides.
- Rename clickHandler -> onClick to match React conventions.
- Complete PropTypes for every accepted prop with oneOf constraints.
- Extend Button.test.js with cases for disabled behavior, transient
  prop leak guard, internal vs external links, title forwarding, and
  aria-hidden on decorative spans (13 tests, all green).